### PR TITLE
use correct framework

### DIFF
--- a/src/Hl7.Fhir.Base.FhirPath.Validator/Hl7.Fhir.Base.FhirPath.Validator.csproj
+++ b/src/Hl7.Fhir.Base.FhirPath.Validator/Hl7.Fhir.Base.FhirPath.Validator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>Hl7.Fhir.Base.FhirPath.Validator</AssemblyName>
     <PackageId>brianpos.Fhir.Base.FhirPath.Validator</PackageId>
     <Version>5.10.2-rc1</Version>

--- a/src/Hl7.Fhir.R4.FhirPath.Validator/Hl7.Fhir.R4.FhirPath.Validator.csproj
+++ b/src/Hl7.Fhir.R4.FhirPath.Validator/Hl7.Fhir.R4.FhirPath.Validator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>Hl7.Fhir.R4.FhirPath.Validator</AssemblyName>
     <PackageId>brianpos.Fhir.R4.FhirPath.Validator</PackageId>
     <Version>5.10.2-rc1</Version>

--- a/src/Hl7.Fhir.R4B.FhirPath.Validator/Hl7.Fhir.R4B.FhirPath.Validator.csproj
+++ b/src/Hl7.Fhir.R4B.FhirPath.Validator/Hl7.Fhir.R4B.FhirPath.Validator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>Hl7.Fhir.R4B.FhirPath.Validator</AssemblyName>
     <PackageId>brianpos.Fhir.R4B.FhirPath.Validator</PackageId>
     <Version>5.10.2-rc1</Version>

--- a/src/Hl7.Fhir.R5.FhirPath.Validator/Hl7.Fhir.R5.FhirPath.Validator.csproj
+++ b/src/Hl7.Fhir.R5.FhirPath.Validator/Hl7.Fhir.R5.FhirPath.Validator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>Hl7.Fhir.R5.FhirPath.Validator</AssemblyName>
     <PackageId>brianpos.Fhir.R5.FhirPath.Validator</PackageId>
     <Version>5.10.2-rc1</Version>

--- a/src/Test.Fhir.R5.FhirPath.Validator/Test.Fhir.R5.FhirPath.Validator.csproj
+++ b/src/Test.Fhir.R5.FhirPath.Validator/Test.Fhir.R5.FhirPath.Validator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Test.FhirPath.Validator/Test.Fhir.R4B.FhirPath.Validator.csproj
+++ b/src/Test.FhirPath.Validator/Test.Fhir.R4B.FhirPath.Validator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)