### PR TITLE
fix: strip xsi:schemaLocation when deserializing test input files

### DIFF
--- a/src/Test.Fhir.R5.FhirPath.Validator/Hl7UnitTests.cs
+++ b/src/Test.Fhir.R5.FhirPath.Validator/Hl7UnitTests.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Xml.Linq;
 using System.Xml.Serialization;
 using Test.Fhir.R4B.FhirPath.Validator;
 using Test.Fhir.R5.FhirPath.Validator;
@@ -123,7 +124,7 @@ namespace Test.Fhir.FhirPath.Validator
 							if (t.InputFile?.EndsWith("json") == true)
 								r = jsonDS.DeserializeResource(content);
 							else
-								r = xmlDS.DeserializeResource(content);
+								r = DeserializeXmlResource(xmlDS, content);
 
 							var expression = t.Expression.Text;
 							//if (expression.Contains("//") || expression.Contains("/*") && expression.Contains("*/"))
@@ -150,6 +151,43 @@ namespace Test.Fhir.FhirPath.Validator
 				}
 				return result;
 			}
+		}
+
+		internal static Resource DeserializeXmlResource(FhirXmlPocoDeserializer xmlDS, string content)
+		{
+			// Some example files (e.g. r5/parameters-example-html.xml) carry an
+			// xsi:schemaLocation attribute on the root element. The strict Firely XML parser
+			// fatally rejects this attribute, so strip the schema-hint attributes before parsing.
+			var xdoc = XDocument.Parse(content);
+			XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+			xdoc.Descendants().Attributes()
+				.Where(a => a.Name == xsi + "schemaLocation" || a.Name == xsi + "noNamespaceSchemaLocation")
+				.Remove();
+			using (var reader = xdoc.CreateReader())
+			{
+				return xmlDS.DeserializeResource(reader);
+			}
+		}
+
+		[TestMethod]
+		public async System.Threading.Tasks.Task TestDeserializeSchemaLocationExample()
+		{
+			// r5/parameters-example-html.xml carries xsi:schemaLocation on its root element,
+			// which the strict Firely XML parser rejects unless it is stripped first.
+			using var httpClient = new HttpClient();
+			var url = "https://raw.githubusercontent.com/FHIR/fhir-test-cases/master/r5/parameters-example-html.xml";
+			using var response = await httpClient.GetAsync(url);
+			response.EnsureSuccessStatusCode();
+
+			var content = await response.Content.ReadAsStringAsync();
+			StringAssert.Contains(content, "schemaLocation", "Upstream example should still carry xsi:schemaLocation");
+
+			var xmlSettings = new FhirXmlPocoDeserializerSettings() { Validator = null, AnnotateResourceParseExceptions = true, ValidateOnFailedParse = false };
+			var xmlDS = new FhirXmlPocoDeserializer(xmlSettings);
+			Resource r = DeserializeXmlResource(xmlDS, content);
+
+			Assert.IsNotNull(r, "Resource with xsi:schemaLocation should deserialize");
+			Assert.AreEqual("Parameters", r.TypeName);
 		}
 
 		[TestMethod]


### PR DESCRIPTION
## Problem
[fhir-test-cases PR #266](https://github.com/FHIR/fhir-test-cases/pull/266) added `r5/parameters-example-html.xml`, whose root `<Parameters>` element carries `xsi:schemaLocation="http://hl7.org/fhir schemas/fhir-single.xsd"`. The R5 test harness deserializes input files with the strict `FhirXmlPocoDeserializer`, which fatally rejects the unknown `schemaLocation` attribute — aborting the entire R5 test run.

## Fix
Add a `DeserializeXmlResource` helper that loads the XML into an `XDocument`, strips `xsi:schemaLocation` / `xsi:noNamespaceSchemaLocation` from any element, then hands it to the Firely parser via `XDocument.CreateReader()`. The XML branch in `ExpressionsInTests` is routed through it; the JSON branch is untouched.

A regression test (`TestDeserializeSchemaLocationExample`) downloads the upstream example and asserts it deserializes to a `Parameters` resource.

## Notes
- Verified against Firely SDK 5.13.4: `DeserializeResource(XmlReader)` calls `MoveToContent()` internally, so a fresh `XDocument` reader is positioned correctly, and it throws on error exactly like the previous string overload (behavior preserved).
- Scope limited to `Test.Fhir.R5.FhirPath.Validator/Hl7UnitTests.cs`.